### PR TITLE
Update blockchain state handling and scheduling

### DIFF
--- a/api/read/base.py
+++ b/api/read/base.py
@@ -2,13 +2,13 @@ from common.metrics_handler import BaseVercelHandler, MetricsHandler
 from config.defaults import MetricsServiceConfig
 from metrics.base import (
     HTTPAccBalanceLatencyMetric,
+    HTTPBlockNumberLatencyMetric,
+    HTTPDebugTraceBlockByNumberLatencyMetric,
     HTTPDebugTraceTxLatencyMetric,
     HTTPEthCallLatencyMetric,
     HTTPTxReceiptLatencyMetric,
 )
 from metrics.ethereum import (
-    HTTPBlockNumberLatencyMetric,
-    HTTPDebugTraceBlockByNumberLatencyMetric,
     WSBlockLatencyMetric,
 )
 

--- a/common/metrics_handler.py
+++ b/common/metrics_handler.py
@@ -13,6 +13,7 @@ import aiohttp
 from common.base_metric import BaseMetric
 from common.factory import MetricFactory
 from common.metric_config import MetricConfig
+from common.state.blockchain_state import BlockchainState
 from config.defaults import MetricsServiceConfig
 
 
@@ -57,6 +58,7 @@ class MetricsHandler:
             endpoints=None,  # Will be set in factory
             extra_params={"tx_data": provider.get("data")},
         )
+        state_data = await BlockchainState.get_data(self.blockchain)
 
         metrics = MetricFactory.create_metrics(
             blockchain_name=self.blockchain,
@@ -68,6 +70,7 @@ class MetricsHandler:
             ws_endpoint=provider.get("websocket_endpoint"),
             http_endpoint=provider.get("http_endpoint"),
             tx_endpoint=provider.get("tx_endpoint"),
+            state_data=state_data,
         )
         await asyncio.gather(*(m.collect_metric() for m in metrics))
 
@@ -103,7 +106,6 @@ class MetricsHandler:
     async def handle(self) -> Tuple[str, str]:
         """Main handler for metric collection and pushing."""
         self._instances = []
-
         try:
             config = json.loads(os.getenv("ENDPOINTS"))
             MetricFactory._registry.clear()

--- a/common/state/blockchain_state.py
+++ b/common/state/blockchain_state.py
@@ -1,0 +1,65 @@
+import logging
+import os
+from typing import Dict
+
+import aiohttp
+
+from config.defaults import BlobStorageConfig
+
+
+class BlockchainState:
+    """Manages blockchain state data retrieval from blob storage."""
+
+    _TIMEOUT = aiohttp.ClientTimeout(total=10)
+
+    @staticmethod
+    async def _get_blob_url(session: aiohttp.ClientSession) -> str:
+        """Get URL of the latest blockchain data blob."""
+        list_url = (
+            f"{BlobStorageConfig.BLOB_BASE_URL}?prefix={BlobStorageConfig.BLOB_FOLDER}/"
+        )
+        headers = {
+            "Authorization": f"Bearer {os.getenv('VERCEL_BLOB_TOKEN')}",
+            "x-store-id": os.getenv("STORE_ID"),
+        }
+
+        async with session.get(list_url, headers=headers) as response:
+            if response.status != 200:
+                raise ValueError(f"Failed to list blobs: {response.status}")
+
+            data = await response.json()
+            blobs = data.get("blobs", [])
+
+            for blob in blobs:
+                if blob["pathname"].endswith(BlobStorageConfig.BLOB_FILENAME):
+                    return blob["url"]
+
+            raise ValueError("Blockchain data blob not found")
+
+    @staticmethod
+    async def _fetch_state_data(session: aiohttp.ClientSession, blob_url: str) -> Dict:
+        """Fetch state data from blob storage."""
+        async with session.get(blob_url) as response:
+            if response.status != 200:
+                raise ValueError(f"Failed to fetch state: {response.status}")
+            return await response.json()
+
+    @staticmethod
+    async def get_data(blockchain: str) -> dict:
+        """Get blockchain state data."""
+        try:
+            async with aiohttp.ClientSession(
+                timeout=BlockchainState._TIMEOUT
+            ) as session:
+                blob_url = await BlockchainState._get_blob_url(session)
+                state_data = await BlockchainState._fetch_state_data(session, blob_url)
+                return state_data.get(blockchain.lower(), {})
+
+        except Exception as e:
+            logging.error(f"State fetch failed: {e!s}")
+            raise
+
+    @staticmethod
+    def clear_cache() -> None:
+        """Maintained for API compatibility."""
+        pass

--- a/metrics/base.py
+++ b/metrics/base.py
@@ -1,105 +1,97 @@
-"""Base EVM metrics implementation for WebSocket and HTTP endpoints."""
+"""Base EVM metrics implementation for HTTP endpoints."""
 
-from common.metric_config import MetricConfig, MetricLabels
 from common.metric_types import HttpCallLatencyMetricBase
 
 
 class HTTPEthCallLatencyMetric(HttpCallLatencyMetricBase):
-    """Collects transaction latency for endpoints using eth_call to simulate a transaction.
-    This metric tracks the time taken for a simulated transaction (eth_call) to be processed by the RPC node.
-    """
+    """Collects response time for eth_call simulation."""
 
-    def __init__(
-        self,
-        handler: "MetricsHandler",  # type: ignore
-        metric_name: str,
-        labels: MetricLabels,
-        config: MetricConfig,
-        **kwargs,
-    ):
-        super().__init__(
-            handler=handler,
-            metric_name=metric_name,
-            labels=labels,
-            config=config,
-            method="eth_call",
-            method_params=[
-                {
-                    "to": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
-                    "data": "0x70a082310000000000000000000000001985ea6e9c68e1c272d8209f3b478ac2fdb25c87",
-                },
-                "latest",
-            ],
-            **kwargs,
-        )
+    @property
+    def method(self) -> str:
+        return "eth_call"
+
+    @staticmethod
+    def get_params_from_state(state_data: dict) -> list:
+        """Get eth_call parameters for USDC token balance query."""
+        return [
+            {
+                "to": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+                "data": "0x70a082310000000000000000000000001985ea6e9c68e1c272d8209f3b478ac2fdb25c87",
+            },
+            "latest",
+        ]
 
 
 class HTTPTxReceiptLatencyMetric(HttpCallLatencyMetricBase):
-    """Collects call latency for the `eth_getTransactionReceipt` method."""
+    """Collects latency for transaction receipt retrieval."""
 
-    def __init__(
-        self,
-        handler: "MetricsHandler",  # type: ignore
-        metric_name: str,
-        labels: MetricLabels,
-        config: MetricConfig,
-        **kwargs,
-    ):
-        super().__init__(
-            handler=handler,
-            metric_name=metric_name,
-            labels=labels,
-            config=config,
-            method="eth_getTransactionReceipt",
-            method_params=[
-                "0x1759c699e6e2b1f249fa0ed605c0de18998bc66556cd6ea3362f92f511aeb06a"
-            ],
-            **kwargs,
-        )
+    @property
+    def method(self) -> str:
+        return "eth_getTransactionReceipt"
+
+    @staticmethod
+    def validate_state(state_data: dict) -> bool:
+        """Validate blockchain state contains transaction hash."""
+        return bool(state_data and state_data.get("tx"))
+
+    @staticmethod
+    def get_params_from_state(state_data: dict) -> list:
+        """Get parameters using transaction hash from state."""
+        return [state_data["tx"]]
 
 
 class HTTPAccBalanceLatencyMetric(HttpCallLatencyMetricBase):
-    """Collects call latency for the `eth_getBalance` method."""
+    """Collects latency for account balance queries."""
 
-    def __init__(
-        self,
-        handler: "MetricsHandler",  # type: ignore
-        metric_name: str,
-        labels: MetricLabels,
-        config: MetricConfig,
-        **kwargs,
-    ):
-        super().__init__(
-            handler=handler,
-            metric_name=metric_name,
-            labels=labels,
-            config=config,
-            method="eth_getBalance",
-            method_params=["0xF977814e90dA44bFA03b6295A0616a897441aceC", "latest"],
-            **kwargs,
-        )
+    @property
+    def method(self) -> str:
+        return "eth_getBalance"
+
+    @staticmethod
+    def get_params_from_state(state_data: dict) -> list:
+        """Get parameters with fixed monitoring address."""
+        return ["0xF977814e90dA44bFA03b6295A0616a897441aceC", "latest"]
 
 
 class HTTPDebugTraceTxLatencyMetric(HttpCallLatencyMetricBase):
-    """Collects call latency for the `debug_traceTransaction` method."""
+    """Collects latency for transaction tracing."""
 
-    def __init__(
-        self,
-        handler: "MetricsHandler",  # type: ignore
-        metric_name: str,
-        labels: MetricLabels,
-        config: MetricConfig,
-        **kwargs,
-    ):
-        super().__init__(
-            handler=handler,
-            metric_name=metric_name,
-            labels=labels,
-            config=config,
-            method="debug_traceTransaction",
-            method_params=[
-                "0x317888c89fe0914c6d11be51acf758742afbe0cf1fdac11f19d35d6ed652ac29",
-                {"tracer": "callTracer"},
-            ],
-            **kwargs,
-        )
+    @property
+    def method(self) -> str:
+        return "debug_traceTransaction"
+
+    @staticmethod
+    def validate_state(state_data: dict) -> bool:
+        """Validate blockchain state contains transaction hash."""
+        return bool(state_data and state_data.get("tx"))
+
+    @staticmethod
+    def get_params_from_state(state_data: dict) -> list:
+        """Get parameters using transaction hash from state."""
+        return [state_data["tx"], {"tracer": "callTracer"}]
+
+
+class HTTPDebugTraceBlockByNumberLatencyMetric(HttpCallLatencyMetricBase):
+    """Collects call latency for the `debug_traceBlockByNumber` method."""
+
+    @property
+    def method(self) -> str:
+        return "debug_traceBlockByNumber"
+
+    @staticmethod
+    def get_params_from_state(state_data: dict) -> list:
+        """Get fixed parameters for latest block tracing."""
+        return ["latest", {"tracer": "callTracer"}]
+
+
+class HTTPBlockNumberLatencyMetric(HttpCallLatencyMetricBase):
+    """Collects call latency for the `eth_blockNumber` method."""
+
+    @property
+    def method(self) -> str:
+        return "eth_blockNumber"
+
+    @staticmethod
+    def get_params_from_state(state_data: dict) -> list:
+        """Get empty parameter list for block number query."""
+        return []

--- a/metrics/solana.py
+++ b/metrics/solana.py
@@ -1,249 +1,103 @@
-"""Solana metrics implementation for WebSocket and HTTP endpoints."""
+"""Solana metrics implementation for HTTP endpoints."""
 
-import asyncio
-import json
-import logging
-from datetime import datetime, timezone
-from typing import Any, Dict, Optional
-
-from websockets.client import WebSocketClientProtocol
-
-from common.metric_config import MetricConfig, MetricLabelKey, MetricLabels
-from common.metric_types import HttpCallLatencyMetricBase, WebSocketMetric
-
-
-class WSBlockLatencyMetric(WebSocketMetric):
-    """Collects block latency for Solana providers using a WebSocket connection.
-    Suitable for serverless invocation: connects, subscribes, collects one message, and disconnects.
-    """
-
-    def __init__(
-        self,
-        handler: "MetricsHandler",  # type: ignore
-        metric_name: str,
-        labels: MetricLabels,
-        config: MetricConfig,
-        **kwargs: Dict[str, Any],
-    ):
-        ws_endpoint: str = kwargs.get("ws_endpoint", "")
-        super().__init__(
-            handler=handler,
-            metric_name=metric_name,
-            labels=labels,
-            config=config,
-            ws_endpoint=ws_endpoint,
-        )
-        self.labels.update_label(MetricLabelKey.API_METHOD, "blockSubscribe")
-        self.last_block_hash: Optional[str] = None
-
-    async def subscribe(self, websocket: WebSocketClientProtocol) -> None:
-        """Subscribe to the newBlocks event on the WebSocket endpoint."""
-        subscription_msg: str = json.dumps(
-            {
-                "jsonrpc": "2.0",
-                "id": 1,
-                "method": "blockSubscribe",
-                "params": [
-                    {
-                        "commitment": "confirmed",
-                        "encoding": "jsonParsed",
-                    }
-                ],
-            }
-        )
-        await websocket.send(subscription_msg)
-        response: str = await websocket.recv()
-        subscription_data: Dict[str, Any] = json.loads(response)
-
-        if subscription_data.get("result") is None:
-            raise ValueError("Subscription to new blocks failed")
-
-        self.subscription_id = subscription_data.get("result")
-
-    async def unsubscribe(self, websocket: WebSocketClientProtocol) -> None:
-        """Unsubscribe from the block subscription."""
-        unsubscribe_msg: str = json.dumps(
-            {
-                "jsonrpc": "2.0",
-                "id": 1,
-                "method": "blockUnsubscribe",
-                "params": [self.subscription_id],
-            }
-        )
-        await websocket.send(unsubscribe_msg)
-        response = await websocket.recv()
-        response_data = json.loads(response)
-
-        if not response_data.get("result", False):
-            logging.warning("Unsubscribe call failed or returned false")
-        else:
-            logging.debug("Successfully unsubscribed from block subscription")
-
-    async def listen_for_data(
-        self, websocket: WebSocketClientProtocol
-    ) -> Optional[Dict[str, Any]]:
-        """Listen for a single data message from the WebSocket and process block latency."""
-        response = await asyncio.wait_for(websocket.recv(), timeout=self.config.timeout)
-        response_data: Dict[str, Any] = json.loads(response)
-
-        if "params" in response_data:
-            block = response_data["params"]["result"]
-            return block
-
-        return None
-
-    def process_data(self, block_info: Dict[str, Any]) -> float:
-        """Calculate block latency in seconds."""
-        block_time: Optional[int] = block_info.get("blockTime")
-
-        if block_time is None:
-            raise ValueError("Block time missing in block data")
-
-        block_datetime: datetime = datetime.fromtimestamp(block_time, timezone.utc)
-        current_time: datetime = datetime.now(timezone.utc)
-        latency: float = (current_time - block_datetime).total_seconds()
-        return latency
+from common.metric_types import HttpCallLatencyMetricBase
 
 
 class HTTPSimulateTxLatencyMetric(HttpCallLatencyMetricBase):
-    """Collects call latency for the `simulateTransaction` method."""
+    """Collects call latency for the simulateTransaction method."""
 
-    def __init__(
-        self,
-        handler: "MetricsHandler",  # type: ignore
-        metric_name: str,
-        labels: MetricLabels,
-        config: MetricConfig,
-        **kwargs,
-    ):
-        super().__init__(
-            handler=handler,
-            metric_name=metric_name,
-            labels=labels,
-            config=config,
-            method="simulateTransaction",
-            method_params=[
-                "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAEDArczbMia1tLmq7zz4DinMNN0pJ1JtLdqIJPUw3YrGCzYAMHBsgN27lcgB6H2WQvFgyZuJYHa46puOQo9yQ8CVQbd9uHXZaGT2cvhRs7reawctIXtX1s3kTqM9YV+/wCp20C7Wj2aiuk5TReAXo+VTVg8QTHjs0UjNMMKCvpzZ+ABAgEBARU=",
-                {"encoding": "base64"},
-            ],
-            **kwargs,
-        )
+    @property
+    def method(self) -> str:
+        return "simulateTransaction"
+
+    @staticmethod
+    def get_params_from_state(state_data: dict) -> list:
+        """Get parameters for simulating a token transfer."""
+        return [
+            "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAEDArczbMia1tLmq7zz4DinMNN0pJ1JtLdqIJPUw3YrGCzYAMHBsgN27lcgB6H2WQvFgyZuJYHa46puOQo9yQ8CVQbd9uHXZaGT2cvhRs7reawctIXtX1s3kTqM9YV+/wCp20C7Wj2aiuk5TReAXo+VTVg8QTHjs0UjNMMKCvpzZ+ABAgEBARU=",
+            {"encoding": "base64"},
+        ]
 
 
 class HTTPGetRecentBlockhashLatencyMetric(HttpCallLatencyMetricBase):
-    """Collects call latency for the `getLatestBlockhash` method."""
+    """Collects call latency for the getLatestBlockhash method."""
 
-    def __init__(
-        self,
-        handler: "MetricsHandler",  # type: ignore
-        metric_name: str,
-        labels: MetricLabels,
-        config: MetricConfig,
-        **kwargs,
-    ):
-        super().__init__(
-            handler=handler,
-            metric_name=metric_name,
-            labels=labels,
-            config=config,
-            method="getLatestBlockhash",
-            method_params=None,
-            **kwargs,
-        )
+    @property
+    def method(self) -> str:
+        return "getLatestBlockhash"
+
+    @staticmethod
+    def get_params_from_state(state_data: dict) -> list:
+        """Get empty parameters list for blockhash retrieval."""
+        return []
 
 
 class HTTPGetTxLatencyMetric(HttpCallLatencyMetricBase):
-    """Collects call latency for the `getTransaction` method."""
+    """Collects call latency for the getTransaction method."""
 
-    def __init__(
-        self,
-        handler: "MetricsHandler",  # type: ignore
-        metric_name: str,
-        labels: MetricLabels,
-        config: MetricConfig,
-        **kwargs,
-    ):
-        super().__init__(
-            handler=handler,
-            metric_name=metric_name,
-            labels=labels,
-            config=config,
-            method="getTransaction",
-            method_params=[
-                "4VAGET7z5g7ogVGmbmZ6KBtF6DS8ftLWzD65BXZWQJjwASUqLod7LhGB6mqThcqo97QcC7r7uNmBY8GwsnLAA52n",
-                {"encoding": "jsonParsed", "maxSupportedTransactionVersion": 0},
-            ],
-            **kwargs,
-        )
+    @property
+    def method(self) -> str:
+        return "getTransaction"
+
+    @staticmethod
+    def validate_state(state_data: dict) -> bool:
+        """Validate blockchain state contains transaction signature."""
+        return bool(state_data and state_data.get("tx"))
+
+    @staticmethod
+    def get_params_from_state(state_data: dict) -> list:
+        """Get parameters using transaction signature from state."""
+        return [
+            state_data["tx"],
+            {"encoding": "jsonParsed", "maxSupportedTransactionVersion": 0},
+        ]
 
 
 class HTTPGetBalanceLatencyMetric(HttpCallLatencyMetricBase):
-    """Collects call latency for the `getBalance` method."""
+    """Collects call latency for the getBalance method."""
 
-    def __init__(
-        self,
-        handler: "MetricsHandler",  # type: ignore
-        metric_name: str,
-        labels: MetricLabels,
-        config: MetricConfig,
-        **kwargs,
-    ):
-        super().__init__(
-            handler=handler,
-            metric_name=metric_name,
-            labels=labels,
-            config=config,
-            method="getBalance",
-            method_params=["9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM"],
-            **kwargs,
-        )
+    @property
+    def method(self) -> str:
+        return "getBalance"
+
+    @staticmethod
+    def get_params_from_state(state_data: dict) -> list:
+        """Get parameters for balance check of monitoring address."""
+        return ["9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM"]
 
 
 class HTTPGetBlockLatencyMetric(HttpCallLatencyMetricBase):
-    """Collects call latency for the `getBlock` method."""
+    """Collects call latency for the getBlock method."""
 
-    def __init__(
-        self,
-        handler: "MetricsHandler",  # type: ignore
-        metric_name: str,
-        labels: MetricLabels,
-        config: MetricConfig,
-        **kwargs,
-    ):
-        super().__init__(
-            handler=handler,
-            metric_name=metric_name,
-            labels=labels,
-            config=config,
-            method="getBlock",
-            method_params=[
-                239462061,
-                {"encoding": "jsonParsed", "maxSupportedTransactionVersion": 0},
-            ],
-            **kwargs,
-        )
+    @property
+    def method(self) -> str:
+        return "getBlock"
+
+    @staticmethod
+    def validate_state(state_data: dict) -> bool:
+        """Validate blockchain state contains block slot number."""
+        return bool(state_data and state_data.get("block"))
+
+    @staticmethod
+    def get_params_from_state(state_data: dict) -> list:
+        """Get parameters using block slot from state."""
+        return [
+            int(state_data["block"]),
+            {"encoding": "jsonParsed", "maxSupportedTransactionVersion": 0},
+        ]
 
 
 class HTTPGetProgramAccsLatencyMetric(HttpCallLatencyMetricBase):
-    """Collects call latency for the `getProgramAccounts` method."""
+    """Collects call latency for the getProgramAccounts method."""
 
-    def __init__(
-        self,
-        handler: "MetricsHandler",  # type: ignore
-        metric_name: str,
-        labels: MetricLabels,
-        config: MetricConfig,
-        **kwargs,
-    ):
-        super().__init__(
-            handler=handler,
-            metric_name=metric_name,
-            labels=labels,
-            config=config,
-            method="getProgramAccounts",
-            method_params=[
-                "FsJ3A3u2vn5cTVofAjvy6y5kwABJAqYWpe4975bi2epH",
-                {"encoding": "jsonParsed"},
-            ],
-            **kwargs,
-        )
+    @property
+    def method(self) -> str:
+        return "getProgramAccounts"
+
+    @staticmethod
+    def get_params_from_state(state_data: dict) -> list:
+        """Get parameters for program accounts query."""
+        return [
+            "FsJ3A3u2vn5cTVofAjvy6y5kwABJAqYWpe4975bi2epH",
+            {"encoding": "jsonParsed"},
+        ]

--- a/metrics/ton.py
+++ b/metrics/ton.py
@@ -1,136 +1,98 @@
 """TON (The Open Network) metrics implementation for HTTP endpoints."""
 
-from common.metric_config import MetricConfig, MetricLabels
 from common.metric_types import HttpCallLatencyMetricBase
 
 
 class HTTPRunGetMethodLatencyMetric(HttpCallLatencyMetricBase):
-    """Collects call latency for the `runGetMethod` method."""
+    """Collects call latency for smart contract method execution."""
 
-    def __init__(
-        self,
-        handler: "MetricsHandler",  # type: ignore
-        metric_name: str,
-        labels: MetricLabels,
-        config: MetricConfig,
-        **kwargs,
-    ):
-        super().__init__(
-            handler=handler,
-            metric_name=metric_name,
-            labels=labels,
-            config=config,
-            method="runGetMethod",
-            method_params={
-                "address": "EQCxE6mUtQJKFnGfaROTKOt1lZbDiiX1kCixRv7Nw2Id_sDs",
-                "method": "get_wallet_address",
-                "stack": [
-                    [
-                        "tvm.Slice",
-                        "te6cckEBAQEAJAAAQ4AbUzrTQYTUv8s/I9ds2TSZgRjyrgl2S2LKcZMEFcxj6PARy3rF",
-                    ]
-                ],
-            },
-            **kwargs,
-        )
+    @property
+    def method(self) -> str:
+        return "runGetMethod"
+
+    @staticmethod
+    def get_params_from_state(state_data: dict) -> dict:
+        """Returns parameters for TVM smart contract method call."""
+        return {
+            "address": "EQCxE6mUtQJKFnGfaROTKOt1lZbDiiX1kCixRv7Nw2Id_sDs",
+            "method": "get_wallet_address",
+            "stack": [
+                [
+                    "tvm.Slice",
+                    "te6cckEBAQEAJAAAQ4AbUzrTQYTUv8s/I9ds2TSZgRjyrgl2S2LKcZMEFcxj6PARy3rF",
+                ]
+            ],
+        }
 
 
 class HTTPGetBlockHeaderLatencyMetric(HttpCallLatencyMetricBase):
-    """Collects call latency for the `getBlockHeader` method."""
+    """Collects call latency for masterchain block header retrieval."""
 
-    def __init__(
-        self,
-        handler: "MetricsHandler",  # type: ignore
-        metric_name: str,
-        labels: MetricLabels,
-        config: MetricConfig,
-        **kwargs,
-    ):
-        super().__init__(
-            handler=handler,
-            metric_name=metric_name,
-            labels=labels,
-            config=config,
-            method="getBlockHeader",
-            method_params={
-                "workchain": -1,
-                "shard": "-9223372036854775808",
-                "seqno": 39064874,
-            },
-            **kwargs,
-        )
+    @property
+    def method(self) -> str:
+        return "getBlockHeader"
+
+    @staticmethod
+    def validate_state(state_data: dict) -> bool:
+        """Validates that required block identifier exists in state data."""
+        return bool(state_data and state_data.get("block"))
+
+    @staticmethod
+    def get_params_from_state(state_data: dict) -> dict:
+        """Returns parameters using TON block identifier components."""
+        workchain, shard, seqno = state_data["block"].split(":")
+        return {
+            "workchain": int(workchain),
+            "shard": shard,
+            "seqno": int(seqno),
+        }
 
 
 class HTTPGetWalletTxsLatencyMetric(HttpCallLatencyMetricBase):
-    """Collects call latency for the `getWalletInformation` method."""
+    """Collects call latency for TON wallet information retrieval."""
 
-    def __init__(
-        self,
-        handler: "MetricsHandler",  # type: ignore
-        metric_name: str,
-        labels: MetricLabels,
-        config: MetricConfig,
-        **kwargs,
-    ):
-        super().__init__(
-            handler=handler,
-            metric_name=metric_name,
-            labels=labels,
-            config=config,
-            method="getWalletInformation",
-            method_params={
-                "address": "EQDtFpEwcFAEcRe5mLVh2N6C0x-_hJEM7W61_JLnSF74p4q2"
-            },
-            **kwargs,
-        )
+    @property
+    def method(self) -> str:
+        return "getWalletInformation"
+
+    @staticmethod
+    def get_params_from_state(state_data: dict) -> dict:
+        """Returns parameters for TON wallet query."""
+        return {"address": "EQDtFpEwcFAEcRe5mLVh2N6C0x-_hJEM7W61_JLnSF74p4q2"}
 
 
 class HTTPGetAddressBalanceLatencyMetric(HttpCallLatencyMetricBase):
-    """Collects call latency for the `getAddressBalance` method."""
+    """Collects call latency for TON address balance queries."""
 
-    def __init__(
-        self,
-        handler: "MetricsHandler",  # type: ignore
-        metric_name: str,
-        labels: MetricLabels,
-        config: MetricConfig,
-        **kwargs,
-    ):
-        super().__init__(
-            handler=handler,
-            metric_name=metric_name,
-            labels=labels,
-            config=config,
-            method="getAddressBalance",
-            method_params={
-                "address": "EQDtFpEwcFAEcRe5mLVh2N6C0x-_hJEM7W61_JLnSF74p4q2"
-            },
-            **kwargs,
-        )
+    @property
+    def method(self) -> str:
+        return "getAddressBalance"
+
+    @staticmethod
+    def get_params_from_state(state_data: dict) -> dict:
+        """Returns parameters for TON address balance check."""
+        return {"address": "EQDtFpEwcFAEcRe5mLVh2N6C0x-_hJEM7W61_JLnSF74p4q2"}
 
 
 class HTTPGetBlockTxsLatencyMetric(HttpCallLatencyMetricBase):
-    """Collects call latency for the `getBlockTransactions` method."""
+    """Collects call latency for TON block transactions retrieval."""
 
-    def __init__(
-        self,
-        handler: "MetricsHandler",  # type: ignore
-        metric_name: str,
-        labels: MetricLabels,
-        config: MetricConfig,
-        **kwargs,
-    ):
-        super().__init__(
-            handler=handler,
-            metric_name=metric_name,
-            labels=labels,
-            config=config,
-            method="getBlockTransactions",
-            method_params={
-                "workchain": -1,
-                "shard": "-9223372036854775808",
-                "seqno": 39064874,
-                "count": 40,
-            },
-            **kwargs,
-        )
+    @property
+    def method(self) -> str:
+        return "getBlockTransactions"
+
+    @staticmethod
+    def validate_state(state_data: dict) -> bool:
+        """Validates that required block identifier exists in state data."""
+        return bool(state_data and state_data.get("block"))
+
+    @staticmethod
+    def get_params_from_state(state_data: dict) -> dict:
+        """Returns parameters using TON block identifier components."""
+        workchain, shard, seqno = state_data["block"].split(":")
+        return {
+            "workchain": int(workchain),
+            "shard": shard,
+            "seqno": int(seqno),
+            "count": 40,
+        }

--- a/tests/test_api_read.py
+++ b/tests/test_api_read.py
@@ -29,9 +29,9 @@ def main():
     setup_environment()
 
     # Import handler after environment setup
-    from api.read.solana import handler as SolanaHandler
+    from api.read.base import handler as Handler
 
-    server = HTTPServer(("localhost", 8000), SolanaHandler)
+    server = HTTPServer(("localhost", 8000), Handler)
     print("Server started at http://localhost:8000")
     server.serve_forever()
 

--- a/vercel.json
+++ b/vercel.json
@@ -42,7 +42,7 @@
     },
     {
       "path": "/api/support/update_state",
-      "schedule": "0 0 * * *"
+      "schedule": "*/20 * * * *"
     }
   ]
 }


### PR DESCRIPTION
Replaces hardcoded query parameters with dynamic values from blockchain-data.json to ensure metrics use recent block/transaction data. Updates state collection configuration to optimize provider usage and frequency.

Changes:

- Use blockchain-data.json (Vercel Blob storage) for recent block/tx parameters
- Restrict blockchain state update to use Chainstack (to reduce not measured API calls to other providers)
- Update state update schedule to run every 20 minutes