### PR TITLE
Add second endpoint for Solana landing metric

### DIFF
--- a/common/factory.py
+++ b/common/factory.py
@@ -1,21 +1,30 @@
 """Factory for creating blockchain-specific metric instances."""
 
 import copy
+from dataclasses import dataclass
 from typing import Dict, List, Tuple, Type
 
 from common.base_metric import BaseMetric
 from common.metric_config import EndpointConfig, MetricConfig, MetricLabels
 
 
+@dataclass
+class MetricRegistration:  # Added: Type-safe registration container
+    metric_class: Type[BaseMetric]
+    metric_name: str
+
+
 class MetricFactory:
     """Creates metric instances for blockchains."""
 
-    _registry: Dict[str, List[Tuple[Type[BaseMetric], str]]] = {}
+    _registry: Dict[str, List[MetricRegistration]] = (
+        {}
+    )  # Modified: Using type-safe registration
 
     @classmethod
     def register(
         cls, blockchain_metrics: Dict[str, List[Tuple[Type[BaseMetric], str]]]
-    ):
+    ) -> None:
         """Registers metric classes for blockchains."""
         for blockchain_name, metrics in blockchain_metrics.items():
             if blockchain_name not in cls._registry:
@@ -23,7 +32,9 @@ class MetricFactory:
             for metric in metrics:
                 if isinstance(metric, tuple) and len(metric) == 2:
                     metric_class, metric_name = metric
-                    cls._registry[blockchain_name].append((metric_class, metric_name))
+                    cls._registry[blockchain_name].append(
+                        MetricRegistration(metric_class, metric_name)
+                    )
                 else:
                     raise ValueError(
                         "Each metric must be a tuple (metric_class, metric_name)"
@@ -33,34 +44,32 @@ class MetricFactory:
     def create_metrics(
         cls,
         blockchain_name: str,
-        metrics_handler: "MetricsHandler",  # type: ignore
+        metrics_handler: "MetricsHandler",  # type: ignore  # noqa: F821
         config: MetricConfig,
-        **kwargs,
+        **kwargs: Dict,
     ) -> List[BaseMetric]:
+        """Creates metric instances for a specific blockchain."""
         if blockchain_name not in cls._registry:
             available = list(cls._registry.keys())
             raise ValueError(
                 f"No metric classes registered for blockchain '{blockchain_name}'. Available blockchains: {available}"
             )
 
+        # Added: Extracted config setup to separate method
+        cls._setup_endpoint_config(config, kwargs)
+
         source_region = kwargs.get("source_region", "default")
         target_region = kwargs.get("target_region", "default")
         provider = kwargs.get("provider", "default")
 
-        config.endpoints = EndpointConfig(
-            main_endpoint=kwargs.get("http_endpoint"),
-            # tx_endpoint=kwargs.get("tx_endpoint"),
-            ws_endpoint=kwargs.get("ws_endpoint"),
-        )
         metrics = []
-
-        for metric_class, metric_name in cls._registry[blockchain_name]:
-            if metric_class.__name__ == "SolanaLandingMetric":
+        for registration in cls._registry[blockchain_name]:
+            if registration.metric_class.__name__ == "SolanaLandingMetric":
                 metrics.extend(
                     cls._create_solana_metrics(
                         blockchain_name,
-                        metric_class,
-                        metric_name,
+                        registration.metric_class,
+                        registration.metric_name,
                         metrics_handler,
                         config,
                         kwargs,
@@ -73,8 +82,8 @@ class MetricFactory:
                 metrics.append(
                     cls._create_single_metric(
                         blockchain_name,
-                        metric_class,
-                        metric_name,
+                        registration.metric_class,
+                        registration.metric_name,
                         metrics_handler,
                         config,
                         kwargs,
@@ -87,18 +96,28 @@ class MetricFactory:
         return metrics
 
     @staticmethod
+    def _setup_endpoint_config(
+        config: MetricConfig, kwargs: Dict
+    ) -> None:  # Added: Extracted method
+        """Sets up endpoint configuration from kwargs."""
+        config.endpoints = EndpointConfig(
+            main_endpoint=kwargs.get("http_endpoint"),
+            ws_endpoint=kwargs.get("ws_endpoint"),
+        )
+
+    @staticmethod
     def _create_solana_metrics(
-        blockchain_name,
-        metric_class,
-        metric_name,
-        metrics_handler,
-        config,
-        kwargs,
-        source_region,
-        target_region,
-        provider,
+        blockchain_name: str,  # Added: Type hints
+        metric_class: Type[BaseMetric],
+        metric_name: str,
+        metrics_handler: "MetricsHandler",
+        config: MetricConfig,
+        kwargs: Dict,
+        source_region: str,
+        target_region: str,
+        provider: str,
     ) -> List[BaseMetric]:
-        """Creates SolanaLandingMetric-specific instances, handling both http_endpoint and tx_endpoint."""
+        """Creates SolanaLandingMetric-specific instances."""
         metrics = []
 
         # First instance using http_endpoint as main endpoint (already set)
@@ -138,15 +157,15 @@ class MetricFactory:
 
     @staticmethod
     def _create_single_metric(
-        blockchain_name,
-        metric_class,
-        metric_name,
-        metrics_handler,
-        config,
-        kwargs,
-        source_region,
-        target_region,
-        provider,
+        blockchain_name: str,  # Added: Type hints
+        metric_class: Type[BaseMetric],
+        metric_name: str,
+        metrics_handler: "MetricsHandler",
+        config: MetricConfig,
+        kwargs: Dict,
+        source_region: str,
+        target_region: str,
+        provider: str,
     ) -> BaseMetric:
         """Creates a single metric instance."""
         labels = MetricLabels(
@@ -161,6 +180,6 @@ class MetricFactory:
             metric_name=metric_name,
             labels=labels,
             config=config,
-            **kwargs,
+            **kwargs.copy(),  # Modified: Added defensive copy
         )
         return metric_instance

--- a/common/metric_config.py
+++ b/common/metric_config.py
@@ -31,7 +31,7 @@ class EndpointConfig:
 
     def get_endpoint(self, method: str) -> Optional[str]:
         """Returns appropriate endpoint based on method."""
-        if method == "sendTransaction" and self.tx_endpoint:
+        if method == "NOT_USED_ANYMORE" and self.tx_endpoint:
             return self.tx_endpoint
         return self.main_endpoint
 

--- a/tests/test_api_write.py
+++ b/tests/test_api_write.py
@@ -1,0 +1,40 @@
+"""Run local development server for blockchain metrics collection."""
+
+import json
+import os
+import sys
+from http.server import HTTPServer
+from pathlib import Path
+
+import dotenv
+
+project_root = str(Path(__file__).parent.parent)
+sys.path.append(project_root)
+
+
+def setup_environment():
+    """Load environment and endpoints configuration."""
+    env_path = Path(project_root) / ".env.local"
+    print(f"Looking for .env.local at: {env_path}")
+
+    dotenv.load_dotenv(env_path)
+    endpoints_path = Path(project_root) / "endpoints.json"
+
+    with open(endpoints_path) as f:
+        os.environ["ENDPOINTS"] = json.dumps(json.load(f))
+
+
+def main():
+    """Start local development server."""
+    setup_environment()
+
+    # Import handler after environment setup
+    from api.write.solana import handler as Handler
+
+    server = HTTPServer(("localhost", 8000), Handler)
+    print("Server started at http://localhost:8000")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Solana providers with both endpoints (default one and one for sending transactions) need measure landing rate for both endpoints (all other metrics are only for the default one), and Grafana needs to distinguish them by provider labels.

Add second endpoint for Solana landing metric when `tx_endpoint` is available.

Changes:
- modified `create_metrics()` to create a second SolanaLandingMetric instance for providers with `tx_endpoint`
- behavior for other blockchain metrics unchanged