### PR TITLE
 Adjust Solana landing rate timeouts and retries

### DIFF
--- a/common/metric_types.py
+++ b/common/metric_types.py
@@ -13,7 +13,7 @@ from common.base_metric import BaseMetric
 from common.metric_config import MetricConfig, MetricLabelKey, MetricLabels
 from common.metrics_handler import MetricsHandler
 
-MAX_RETRIES = 2
+MAX_RETRIES = 3
 
 
 class WebSocketMetric(BaseMetric):
@@ -66,8 +66,6 @@ class WebSocketMetric(BaseMetric):
             if data is not None:
                 latency = self.process_data(data)
                 self.update_metric_value(latency)
-                # if latency > self.config.max_latency:
-                #     raise ValueError(f"Invalid latency: {latency}s")
                 self.mark_success()
                 return
             raise ValueError("No data in response")
@@ -102,8 +100,6 @@ class HttpMetric(BaseMetric):
             if data is not None:
                 latency = self.process_data(data)
                 self.update_metric_value(latency)
-                # if latency > self.config.max_latency:
-                #     raise ValueError(f"Invalid latency: {latency}s")
                 self.mark_success()
                 return
             raise ValueError("No data in response")

--- a/metrics/solana_landing_rate.py
+++ b/metrics/solana_landing_rate.py
@@ -79,7 +79,9 @@ class SolanaLandingMetric(HttpMetric):
                 client.confirm_transaction(
                     signature,
                     commitment=MetricsServiceConfig.SOLANA_CONFIRMATION_LEVEL,
-                    sleep_seconds=0.3,
+                    # We don't use response time in visualizations,
+                    # let's decrease number of polling requests.
+                    sleep_seconds=5,
                 )
             )
             confirmation = await asyncio.wait_for(confirmation_task, timeout=timeout)
@@ -125,7 +127,6 @@ class SolanaLandingMetric(HttpMetric):
             if not response:
                 raise ValueError(response)
         except Exception as e:
-            # raise ValueError(f"Health check failed: {e!s}")
             logging.warning(f"Node health check failed: {e!s}")
 
     async def fetch_data(self) -> Optional[float]:
@@ -137,7 +138,7 @@ class SolanaLandingMetric(HttpMetric):
         client = None
         try:
             client = await self._create_client()
-            await self._check_health(client)
+            # await self._check_health(client)
             tx = await self._prepare_memo_transaction(client)
 
             start_slot = await self._get_slot(client)


### PR DESCRIPTION
Changes:
- Removed redundant health check in Solana landing rate as it's not critical for metric
- Increased sleep interval in transaction confirmation from 0.3s to 5s to reduce the number of RPC calls
- Increased max retries from 2 to 3 for HTTP 429 responses